### PR TITLE
Fix: Removida adição duplicada de PK Columns em JDBC tables

### DIFF
--- a/src/main/java/sgbd/source/table/JDBCTable.java
+++ b/src/main/java/sgbd/source/table/JDBCTable.java
@@ -112,17 +112,6 @@ abstract public class JDBCTable extends Table {
         }
     }
 
-    public ArrayList<String> getPKColumns() {
-        ArrayList<String> pkColumns = new ArrayList<>();
-        for (Column column : header.getPrototype().getColumns()) {
-            if (column.isPrimaryKey()) {
-                pkColumns.add(column.getName());
-            }
-        }
-
-        return pkColumns;
-    }
-
     @Override
     public void clear() {
         throw new DataBaseException("JDBCTable", "This type of table (JDBCTable) is not writable");
@@ -160,7 +149,6 @@ abstract public class JDBCTable extends Table {
                 try {
                     String selectedColumns = "*";
                     if (columns != null) {
-                        columns.addAll(getPKColumns());
                         selectedColumns = columns.toString();
                         selectedColumns = selectedColumns.substring(1, selectedColumns.length() - 1);
                     }


### PR DESCRIPTION
As Primary Keys columns estavam sendo automaticamente adicionadas aos registros do iterator. Isso estava causando duplicações de colunas ao instanciar um iterator com uma lista de colunas.

Exemplo: Em uma table com as colunas `name`, `id` (sendo a PK), antes o resultado seria:
```java
...

RowIterator iterator = table.iterator(columns); // columns = [name, id]
// iterator.columns = [name, id, id]

```

Após o ajuste, apenas as colunas listadas em `columns` são salvas.